### PR TITLE
Added basic Jewels in the Sand functionality.

### DIFF
--- a/plugins/jewels_in_the_sand/jewels_in_the_sand.py
+++ b/plugins/jewels_in_the_sand/jewels_in_the_sand.py
@@ -16,6 +16,10 @@ def process_message(data):
   if not message_text.startswith('jits'):
     return
 
-  # Get the channel and make your presence known!
+  # Retrieve the command.
+  message_tokens = message_text.split()
+  command = message_tokens[1]
+
+  # Execute the command!
   channel = data['channel']
-  outputs.append([channel, 'Jewels in the Sand is fun!'])
+  outputs.append([channel, 'I do not understand the command \'' + command + '\'.'])

--- a/plugins/jewels_in_the_sand/jewels_in_the_sand.py
+++ b/plugins/jewels_in_the_sand/jewels_in_the_sand.py
@@ -1,4 +1,13 @@
+###
+# Imports
+###
+
 from __future__ import unicode_literals
+
+
+###
+# Global Variables
+###
 
 # A list of outputs; append to this list to send a message.
 outputs = []
@@ -6,6 +15,19 @@ outputs = []
 # Lists of jewels and sand for the current game.
 jewel_list = []
 sand_list = []
+
+
+###
+# Bot Utility Functions
+###
+
+def send_message(channel, message):
+  outputs.append([channel, message])
+
+
+###
+# Game Functions
+###
 
 def list_jewels_and_sand(channel):
   # Create the message using the jewels and sand.
@@ -17,7 +39,7 @@ def list_jewels_and_sand(channel):
   message += ', '.join(sand_list)
 
   # Send the message!
-  outputs.append([channel, message])
+  send_message(channel, message)
 
 def add_jewel(jewel, channel):
   # Add the given jewel to the list of jewels.
@@ -25,7 +47,7 @@ def add_jewel(jewel, channel):
 
   # Let everyone know.
   message = '*\'' + jewel + '\'* is a jewel.'
-  outputs.append([channel, message])
+  send_message(channel, message)
 
 def add_sand(sand, channel):
   # Add the given sand to the list of sand.
@@ -33,24 +55,38 @@ def add_sand(sand, channel):
 
   # Let everyone know.
   message = '*\'' + sand + '\'* is sand.'
-  outputs.append([channel, message])
+  send_message(channel, message)
 
 def restart_game(channel):
+  # Specify the global jewel and sand lists.
+  global jewel_list
+  global sand_list
+
   # Clear the jewel and sand lists.
   jewel_list = []
   sand_list = []
 
   # Let everyone know.
   message = 'The game has been restarted.'
-  outputs.append([channel, message])
+  send_message(channel, message)
+
+
+###
+# Error Handling Functions
+###
 
 def handle_missing_params(command, channel):
   message = 'I need more parameters for the command *\'' + command + '\'*.'
-  outputs.append([channel, message])
+  send_message(channel, message)
 
 def handle_unknown_command(command, channel):
   message = 'I do not understand the command *\'' + command + '\'*.'
-  outputs.append([channel, message])
+  send_message(channel, message)
+
+
+###
+# Bot Main Functions
+###
 
 # This function is called whenever a message is received.
 def process_message(data):

--- a/plugins/jewels_in_the_sand/jewels_in_the_sand.py
+++ b/plugins/jewels_in_the_sand/jewels_in_the_sand.py
@@ -1,0 +1,21 @@
+from __future__ import unicode_literals
+
+# A list of outputs; append to this list to send a message.
+outputs = []
+
+# Lists of jewels and sand for the current game.
+jewels = []
+sand = []
+
+# This function is called whenever a message is received.
+def process_message(data):
+  # Get the text.
+  message_text = data['text']
+
+  # This bot only cares about messages that start with "jits".
+  if not message_text.startswith('jits'):
+    return
+
+  # Get the channel and make your presence known!
+  channel = data['channel']
+  outputs.append([channel, 'Jewels in the Sand is fun!'])

--- a/plugins/jewels_in_the_sand/jewels_in_the_sand.py
+++ b/plugins/jewels_in_the_sand/jewels_in_the_sand.py
@@ -4,8 +4,53 @@ from __future__ import unicode_literals
 outputs = []
 
 # Lists of jewels and sand for the current game.
-jewels = []
-sand = []
+jewel_list = []
+sand_list = []
+
+def list_jewels_and_sand(channel):
+  # Create the message using the jewels and sand.
+  message = '>>>'
+  message += '*Jewels:* '
+  message += ', '.join(jewel_list)
+  message += '\n'
+  message += '*Sand:* '
+  message += ', '.join(sand_list)
+
+  # Send the message!
+  outputs.append([channel, message])
+
+def add_jewel(jewel, channel):
+  # Add the given jewel to the list of jewels.
+  jewel_list.append(jewel)
+
+  # Let everyone know.
+  message = '*\'' + jewel + '\'* is a jewel.'
+  outputs.append([channel, message])
+
+def add_sand(sand, channel):
+  # Add the given sand to the list of sand.
+  sand_list.append(sand)
+
+  # Let everyone know.
+  message = '*\'' + sand + '\'* is sand.'
+  outputs.append([channel, message])
+
+def restart_game(channel):
+  # Clear the jewel and sand lists.
+  jewel_list = []
+  sand_list = []
+
+  # Let everyone know.
+  message = 'The game has been restarted.'
+  outputs.append([channel, message])
+
+def handle_missing_params(command, channel):
+  message = 'I need more parameters for the command *\'' + command + '\'*.'
+  outputs.append([channel, message])
+
+def handle_unknown_command(command, channel):
+  message = 'I do not understand the command *\'' + command + '\'*.'
+  outputs.append([channel, message])
 
 # This function is called whenever a message is received.
 def process_message(data):
@@ -16,10 +61,30 @@ def process_message(data):
   if not message_text.startswith('jits'):
     return
 
+  # Retrieve the channel.
+  channel = data['channel']
+
   # Retrieve the command.
   message_tokens = message_text.split()
   command = message_tokens[1]
 
   # Execute the command!
-  channel = data['channel']
-  outputs.append([channel, 'I do not understand the command \'' + command + '\'.'])
+  if command == 'list':
+    list_jewels_and_sand(channel)
+  elif command == 'jewel':
+    if len(message_tokens) < 3:
+      handle_missing_params(command, channel)
+    else:
+      jewel = " ".join(message_tokens[2:])
+      add_jewel(jewel, channel)
+  elif command == 'sand':
+    if len(message_tokens) < 3:
+      handle_missing_params(command, channel)
+    else:
+      sand = " ".join(message_tokens[2:])
+      add_sand(sand, channel)
+  elif command == 'restart':
+    restart_game(channel)
+  else:
+    # We don't understand the command, so we say so.
+    handle_unknown_command(command, channel)


### PR DESCRIPTION
This set of commits adds basic Jewels in the Sand functionality.

The new plugin responds to messages starting with `jits`.  Jewels and sand can be added (`jits [jewel|sand]`), listed (`jits list`), and cleared (`jits restart`).

I've tested it via private message with `stony-dev-hale`.
